### PR TITLE
Dockerfile: Specify location of the `start` binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY start.go /
 
 RUN apt-get -y update \
 && apt-get install -y golang-go \
-&& go build /start.go \
+&& go build -o /start /start.go \
 && apt-get remove --purge -y golang-go $(apt-mark showauto) \
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Before, `start.go` was compiled into the `/data` directory which is the working
directory set by the Redis Dockerfile. This caused the entrypoint `/start` to
fail. We now specify that `start.go` should be compiled into the root directory
instead.