### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./redis.js"
+  "name": "@quilt/redis",
+  "version": "0.0.1",
+  "main": "./redis.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }

--- a/redis-example.js
+++ b/redis-example.js
@@ -1,4 +1,5 @@
-var redis = require("github.com/quilt/redis");
+const {createDeployment, Machine, githubKeys} = require("@quilt/quilt");
+var redis = require("./redis.js");
 
 var deployment = createDeployment({});
 

--- a/redis.js
+++ b/redis.js
@@ -1,3 +1,4 @@
+const {LabelRule, Service, Container} = require("@quilt/quilt");
 var image = "quilt/redis";
 
 function Redis(nWorker, auth) {


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.